### PR TITLE
new: usr: Supports HALO_API_HOSTNAME for use with non-MTG environments.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,3 @@
-# Get the halo-events component
-FROM docker.io/halotools/python-sdk:ubuntu-16.04_sdk-1.1.1 as downloader
-
-ARG HALO_EVENTS_VERSION=v0.11
-
-RUN apt-get update && \
-    apt-get install -y \
-        git
-
-WORKDIR /app/
-
-RUN echo "Target branch for this build: $HALO_EVENTS_VERSION"
-
-RUN git clone https://github.com/cloudpassage/halo-events
-
-RUN cd halo-events && \
-    git archive --verbose --format=tar.gz -o /app/haloevents.tar.gz $HALO_EVENTS_VERSION
-
-
-################################################################
 FROM docker.io/halotools/python-sdk:ubuntu-16.04_sdk-1.1.1
 MAINTAINER toolbox@cloudpassage.com
 
@@ -31,21 +11,42 @@ COPY ./ /app/
 
 RUN mkdir -p /src/halo-events
 WORKDIR /src/halo-events
-COPY --from=downloader /app/haloevents.tar.gz /src/halo-events/haloevents.tar.gz
-RUN tar -zxvf ./haloevents.tar.gz
-RUN pip install .
+
+WORKDIR /app/tool/
+
+RUN /usr/bin/python2.7 -m pip install \
+    boto3==1.5.6 \
+    flake8==3.3.0 \
+    pytest==3.2.3 \
+    pytest-cov==2.5.1 \
+    pytest-flake8==0.8.1
+
+RUN /usr/bin/python2.7 \
+    -m py.test \
+    --cov=eventslib \
+    --cov-report=term-missing \
+    /app/tool/tests -s
+
+################################################################
+
+FROM docker.io/halotools/python-sdk:ubuntu-16.04_sdk-1.1.1
+MAINTAINER toolbox@cloudpassage.com
+
+ENV HALO_API_HOSTNAME=api.cloudpassage.com
+ENV HALO_API_PORT=443
+
+ENV DROP_DIRECTORY=/var/events
+
+RUN mkdir /app
+COPY ./ /app/
+
+RUN mkdir -p /src/halo-events
+WORKDIR /src/halo-events
 
 WORKDIR /app/tool/
 
 RUN pip install \
-    boto3==1.5.6 \
-    codeclimate-test-reporter==0.2.0 \
-    coverage==4.2 \
-    pytest==2.8.0 \
-    pytest-cover==3.0.0 \
-    pytest-flake8==0.1
-
-RUN py.test --cov=eventslib || py.test
+    boto3==1.5.6
 
 RUN mkdir -p $DROP_DIRECTORY
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ S3 bucket you need to drop the events into.
 
 * HALO_API_KEY: sometimes referred to as Key ID
 * HALO_API_SECRET_KEY
+* HALO_API_HOSTNAME (optional, defaults to `api.cloudpassage.com`)
 * TARGET_DATE: Formatted like this: "2016-12-01"
 * LOCAL_OUTPUT_DIR: absolute path to the directory you want your events to land
 in

--- a/tool/eventslib/get_events.py
+++ b/tool/eventslib/get_events.py
@@ -1,17 +1,22 @@
-import haloevents
+import cloudpassage
+from utility import Utility
 
 
 class GetEvents(object):
-    def __init__(self, key, secret, batch_size, target_date):
-        self.h_e = haloevents.HaloEvents(key, secret,
-                                         start_timestamp=target_date)
+    def __init__(self, key, secret, api_hostname, batch_size, target_date):
+        self.ua = Utility.build_ua("")
+        self.session = cloudpassage.HaloSession(key, secret,
+                                                api_host=api_hostname,
+                                                integration_string=self.ua)
         self.target_date = target_date
         self.batch_size = batch_size
+        self.streamer = cloudpassage.TimeSeries(self.session, self.target_date,
+                                                "/v1/events", "events")
         print("Event retrieval initialized for date %s") % self.target_date
 
     def __iter__(self):
         batch = []
-        for event in self.h_e:
+        for event in self.streamer:
             if event["created_at"].startswith(self.target_date):
                 if len(batch) >= self.batch_size:
                     yield list(batch)

--- a/tool/eventslib/utility.py
+++ b/tool/eventslib/utility.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 
@@ -10,3 +11,24 @@ class Utility(object):
             return True
         else:
             return False
+
+    @classmethod
+    def read(cls, fname):
+        return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+    @classmethod
+    def get_version(cls):
+        raw_init_file = Utility.read("__init__.py")
+        rx_compiled = re.compile(r"\s*__version__\s*=\s*\"(\S+)\"")
+        ver = rx_compiled.search(raw_init_file).group(1)
+        return ver
+
+    @classmethod
+    def build_ua(cls, integration_name=""):
+        product = "Halo-Events-Archiver"
+        version = Utility.get_version()
+        if integration_name == "":
+            ua_string = "%s/%s" % (product, version)
+        else:
+            ua_string = "%s %s/%s" % (integration_name, product, version)
+        return ua_string

--- a/tool/runner.py
+++ b/tool/runner.py
@@ -1,6 +1,7 @@
 import cloudpassage
 import eventslib
 import os
+import sys
 import time
 from datetime import datetime
 
@@ -12,8 +13,10 @@ start_time = datetime.now()
 s3_bucket_name = os.getenv("AWS_S3_BUCKET")
 file_number = 0
 counter = 0
+
 event_cache = eventslib.GetEvents(config.key_id, config.secret_key,
-                                  events_per_file, env_date)
+                                  config.api_hostname, events_per_file,
+                                  env_date)
 
 if eventslib.Utility.target_date_is_valid(env_date) is False:
     msg = "Bad date! %s" % env_date


### PR DESCRIPTION
This tool defaults to `api.cloudpassage.com` for HALO_API_HOSTNAME.

Setting this environment variable when running the container
is only necessary for environments which are not in the
CloudPassage MTG.

This commit also includes a refactor of the GetEvents() class,
which now uses the TimeSeries() abstraction in the Python SDK
instead of the halo-events library.

Closes #4